### PR TITLE
Fix a typo in the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rvalp
 
-RISC-V Assemly Language Programming
+RISC-V Assembly Language Programming
 
 This is an attempt to create a book on RISC-V programming in assembly language.
 


### PR DESCRIPTION
Add the missing 'b' into "Assemly" to form the word "Assembly."