### PR TITLE
Fix a typo in chapter "4.2.4 Adding a 12-bit Signed Value": t1 → t0

### DIFF
--- a/book/programs/chapter.tex
+++ b/book/programs/chapter.tex
@@ -173,7 +173,7 @@ For example, to set \reg{t3} to zero:
 {\small
 \begin{verbatim}
     addi    t0, zero, 4     # t0 = 4
-    addi    t1, t1, 100     # t1 = 104
+    addi    t0, t0, 100     # t0 = 104
 
     addi    t0, zero, 0x123     # t0 = 0x123
     addi    t0, t0, 0xfff       # t0 = 0x122 (subtract 1)


### PR DESCRIPTION
I'm not 146% sure, but it should be `t0` in this example, instead of `t1`:
```asm
    addi    t0, zero, 4     # t0 = 4
    addi    t1, t1, 100     # t1 = 104
```